### PR TITLE
CI integration to create PR's 

### DIFF
--- a/.github/workflows/auto_check.yml
+++ b/.github/workflows/auto_check.yml
@@ -1,0 +1,19 @@
+name: Bump upstream version
+
+on:
+  schedule:
+    - cron: "00 */4 * * *"
+  push:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npx @dappnode/dappnodesdk github-action bump-upstream
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}
+          PINATA_SECRET_API_KEY: ${{ secrets.PINATA_SECRET_API_KEY }}

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,6 +2,8 @@
   "name": "ethereum-classic.dnp.dappnode.eth",
   "version": "1.1.1",
   "upstreamVersion": "v1.12.6",
+  "upstreamRepo": "ethereum/go-ethereum",
+  "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "ETC Client by ETC Core",
   "description": "Ethereum Classic is a decentralized platform that runs smart contracts: applications that can be run exactly as programmed without any possibility of downtime, censorship, or third party interference. This packages deploys a node for the Ethereum Classic mainnet.",
   "type": "library",


### PR DESCRIPTION
This github action executes dappnodesdk bump-upstream, in order to check if the current upstream version of the package is the same as the official version of the project.