### PR TITLE
Fix upstream repo

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "name": "ethereum-classic.dnp.dappnode.eth",
   "version": "1.1.1",
   "upstreamVersion": "v1.12.6",
-  "upstreamRepo": "ethereum/go-ethereum",
+  "upstreamRepo": "etclabscore/core-geth",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "ETC Client by ETC Core",
   "description": "Ethereum Classic is a decentralized platform that runs smart contracts: applications that can be run exactly as programmed without any possibility of downtime, censorship, or third party interference. This packages deploys a node for the Ethereum Classic mainnet.",


### PR DESCRIPTION
The upstream repo was geth repo instead https://github.com/etclabscore/core-geth

Fixes change introduced in https://github.com/dappnode/DAppNodePackage-ethereum-classic/pull/12#discussion_r831293083