### PR TITLE
Update Dockerfile: use Go v1.18

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build Core-Geth in a stock Go builder container
-FROM golang:1.15-alpine as builder
+FROM golang:1.18-alpine as builder
 
 ARG UPSTREAM_VERSION
 


### PR DESCRIPTION
This resolves an issue encountered here https://github.com/dappnode/DAppNodePackage-ethereum-classic/pull/16

Note that the base branch here is the target branch of the cited PR. 