### PR TITLE
Make default syncmode  snap instead fast

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,4 +15,4 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/core-geth/build/bin/geth /usr/local/bin
 
-ENTRYPOINT geth --classic --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --syncmode ${SYNCMODE:-fast} $EXTRA_OPTS
+ENTRYPOINT geth --classic --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --syncmode ${SYNCMODE:-snap} $EXTRA_OPTS


### PR DESCRIPTION
the sync mode seems not to have been updated to the fastest option in the Dockerfile since snapshot sync was added to ETC.
snap sync is obviously much faster than fast sync, I've been using a flag to set it to snap myself for at least 6 months in EXTRA_OPTS and its been working.