### PR TITLE
set hardcoded port and remove deprecated flag

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,4 +15,4 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/core-geth/build/bin/geth /usr/local/bin
 
-ENTRYPOINT geth --classic --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --syncmode ${SYNCMODE:-snap} $EXTRA_OPTS
+ENTRYPOINT geth --classic --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --port {$P2P_PORT} --syncmode ${SYNCMODE:-snap} $EXTRA_OPTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,12 @@ services:
     volumes:
       - "geth:/root/.ethereum"
     environment:
-      - "EXTRA_OPTS=--http.api eth,net,web3,txpool --nousb"
-      - SYNCMODE
+      - "EXTRA_OPTS=--http.api eth,net,web3,txpool"
+      - SYNCMODE=snap
+      - P2P_PORT=30913
     ports:
-      - "30303"
-      - 30303/udp
-      - 30304/udp
+      - "30913:30913/udp"
+      - "30913:30913/tcp"
     restart: always
 volumes:
   geth: {}


### PR DESCRIPTION
set hardcoded port as defined in https://github.com/dappnode/DAppNode/issues/457 also removed the deprecated `--no-usb` flag to get rid of a warning about it on boot.